### PR TITLE
Move API registration into class initialization

### DIFF
--- a/se.rb
+++ b/se.rb
@@ -42,7 +42,7 @@ class SE
   attr_accessor :apikey
   
   def initialize(apikey)
-    @apikey = apikey
+    Serel::Base.config('', apikey)
     @se_sites = []
     update_sites()
   end
@@ -69,10 +69,13 @@ class SE
   end
   
   def update_sites()
-    Serel::Base.config('', @apikey)
     @se_sites = Serel::Site.all.
       select { |site| site.site_type == 'main_site' }.
       map    { |site| site.site_url }.
       map    { |url|  extract_domain(url) }
+  end
+
+  def info()
+    Serel::User.get.quota_remaining
   end
 end


### PR DESCRIPTION
This also enables the /info route to return an API quota, suitable for monitoring or debugging when necessary.

/cc @kylecronin 
